### PR TITLE
Implement PPU windowing and update CLAUDE.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ target_include_directories(gba_emulator PRIVATE
     ${SDL2_INCLUDE_DIRS}
 )
 
-target_link_libraries(gba_emulator PRIVATE ${SDL2_LIBRARIES})
+target_link_libraries(gba_emulator PRIVATE ${SDL2_LIBRARIES} m)
 
 if(ENABLE_XRAY)
     target_compile_definitions(gba_emulator PRIVATE ENABLE_XRAY)

--- a/src/ppu/effects.c
+++ b/src/ppu/effects.c
@@ -47,7 +47,14 @@ void ppu_apply_blend_scanline(PPU* ppu) {
     uint32_t evy = ppu->bldy & 0x1F;
     if (evy > 16) evy = 16;
 
+    // Check if any window is enabled — if so, the per-pixel blend flag applies.
+    bool windowing_active = BIT(ppu->dispcnt, 13) || BIT(ppu->dispcnt, 14)
+                          || BIT(ppu->dispcnt, 15);
+
     for (uint32_t x = 0; x < SCREEN_WIDTH; x++) {
+        // If windowing is active and color effects are disabled for this pixel, skip
+        if (windowing_active && !ppu->win_blend_enable[x]) continue;
+
         uint8_t top_id = ppu->top_layer[x];
 
         // All modes require the top pixel to be a 1st target
@@ -94,16 +101,125 @@ void ppu_apply_blend_scanline(PPU* ppu) {
 }
 
 // ---------------------------------------------------------------------------
-// Windowing (stub -- not yet implemented)
+// Windowing
 // ---------------------------------------------------------------------------
 
-// Determine which layers are visible in each window region
-void ppu_apply_windowing(PPU* ppu, int x) {
-    // TODO: Check if pixel (x, vcount) is inside WIN0, WIN1, or OBJ window
-    // Return the layer enable mask for that window region
-    // Fallback to WINOUT if not in any window
-    (void)ppu;
-    (void)x;
+// Check if the current scanline (vcount) falls within a window's vertical range.
+static bool win_v_active(uint16_t win_v, uint16_t vcount) {
+    uint8_t top    = (uint8_t)(win_v >> 8);
+    uint8_t bottom = (uint8_t)(win_v & 0xFF);
+
+    if (top > bottom) {
+        // Wrapping range: active when vcount >= top OR vcount < bottom
+        return (vcount >= top || vcount < bottom);
+    }
+    return (vcount >= top && vcount < bottom);
+}
+
+// Check if a pixel X coordinate falls within a window's horizontal range.
+static bool win_h_active(uint16_t win_h, uint32_t x) {
+    uint8_t left  = (uint8_t)(win_h >> 8);
+    uint8_t right = (uint8_t)(win_h & 0xFF);
+
+    if (left > right) {
+        // Wrapping range: active when x >= left OR x < right
+        return (x >= left || x < right);
+    }
+    return (x >= left && x < right);
+}
+
+// Apply windowing to the fully composited scanline.
+// For each pixel, determine which window region it belongs to (WIN0 > WIN1 >
+// OBJWIN > outside), then check if the top layer is enabled in that region.
+// If the layer is disabled, replace the pixel with the second-priority pixel
+// (if that layer IS enabled), otherwise fall back to backdrop.
+//
+// The "color effects" enable bit (bit 5 of each window's mask) controls whether
+// blending applies to pixels in that region. We store this per-pixel so the
+// subsequent blend pass can consult it.
+void ppu_apply_windowing_scanline(PPU* ppu) {
+    // Windowing is only active if at least one window is enabled in DISPCNT
+    // bits 13 (WIN0), 14 (WIN1), 15 (OBJWIN).
+    bool win0_on  = BIT(ppu->dispcnt, 13);
+    bool win1_on  = BIT(ppu->dispcnt, 14);
+    bool objwin_on = BIT(ppu->dispcnt, 15);
+
+    if (!win0_on && !win1_on && !objwin_on) return;
+
+    // Precompute vertical containment (same for all pixels on this scanline)
+    bool win0_v = win0_on && win_v_active(ppu->win_v[0], ppu->vcount);
+    bool win1_v = win1_on && win_v_active(ppu->win_v[1], ppu->vcount);
+
+    // Extract the 6-bit enable masks for each window region once:
+    //   bits 0-3 = BG0-BG3 enable, bit 4 = OBJ enable, bit 5 = color effects
+    uint8_t win0_mask   = (uint8_t)(ppu->winin & 0x3F);
+    uint8_t win1_mask   = (uint8_t)((ppu->winin >> 8) & 0x3F);
+    uint8_t outside_mask = (uint8_t)(ppu->winout & 0x3F);
+    uint8_t objwin_mask = (uint8_t)((ppu->winout >> 8) & 0x3F);
+
+    // Backdrop color (palette entry 0) for pixels that get fully masked
+    uint16_t backdrop = (uint16_t)ppu->palette_ram[0]
+                      | ((uint16_t)ppu->palette_ram[1] << 8);
+
+    for (uint32_t x = 0; x < SCREEN_WIDTH; x++) {
+        // Determine which window region this pixel belongs to.
+        // Priority: WIN0 > WIN1 > OBJWIN > outside
+        uint8_t mask;
+
+        if (win0_v && win_h_active(ppu->win_h[0], x)) {
+            mask = win0_mask;
+        } else if (win1_v && win_h_active(ppu->win_h[1], x)) {
+            mask = win1_mask;
+        } else if (objwin_on && ppu->obj_window[x]) {
+            mask = objwin_mask;
+        } else {
+            mask = outside_mask;
+        }
+
+        // Check if the top layer is enabled in this window region.
+        // Layer IDs: 0-3 = BG0-BG3, 4 = OBJ, 5 = backdrop
+        uint8_t top_id = ppu->top_layer[x];
+        bool top_enabled;
+
+        if (top_id <= 3) {
+            top_enabled = BIT(mask, top_id);
+        } else if (top_id == 4) {
+            top_enabled = BIT(mask, 4);  // OBJ enable
+        } else {
+            top_enabled = true;  // Backdrop is always visible
+        }
+
+        if (!top_enabled) {
+            // Top pixel is masked out. Try the second pixel.
+            uint8_t second_id = ppu->second_layer[x];
+            bool second_enabled;
+
+            if (second_id <= 3) {
+                second_enabled = BIT(mask, second_id);
+            } else if (second_id == 4) {
+                second_enabled = BIT(mask, 4);
+            } else {
+                second_enabled = true;
+            }
+
+            if (second_enabled) {
+                ppu->scanline_buffer[x] = ppu->second_pixel[x];
+                ppu->top_layer[x] = second_id;
+                // Second becomes backdrop (nothing behind it)
+                ppu->second_pixel[x] = backdrop;
+                ppu->second_layer[x] = 5;
+            } else {
+                // Both masked — show backdrop
+                ppu->scanline_buffer[x] = backdrop;
+                ppu->top_layer[x] = 5;
+                ppu->second_pixel[x] = backdrop;
+                ppu->second_layer[x] = 5;
+            }
+        }
+
+        // Store whether color effects are enabled for this pixel's window region.
+        ppu->win_blend_enable[x] = BIT(mask, 5);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ppu/ppu.c
+++ b/src/ppu/ppu.c
@@ -34,6 +34,7 @@ void ppu_render_scanline(PPU* ppu) {
         ppu->top_layer[x] = 5;       // backdrop
         ppu->second_pixel[x] = backdrop;
         ppu->second_layer[x] = 5;    // backdrop
+        ppu->win_blend_enable[x] = true;
     }
 
     switch (mode) {
@@ -95,6 +96,13 @@ void ppu_render_scanline(PPU* ppu) {
         if (BIT(ppu->dispcnt, 12)) ppu_render_sprites(ppu);
         break;
     }
+
+    // Build OBJ window mask (must happen after sprite rendering)
+    ppu_build_obj_window(ppu);
+
+    // Apply windowing: mask out layers that are disabled in each window region.
+    // Must happen after all compositing, before blending.
+    ppu_apply_windowing_scanline(ppu);
 
     // Apply color blending effects (fade-to-black, fade-to-white, alpha blend)
     ppu_apply_blend_scanline(ppu);

--- a/src/ppu/ppu.h
+++ b/src/ppu/ppu.h
@@ -45,6 +45,12 @@ struct PPU {
     uint16_t second_pixel[SCREEN_WIDTH]; // Color of second-highest-priority pixel
     uint8_t second_layer[SCREEN_WIDTH];  // Layer ID of second pixel
 
+    // OBJ window: true if an OBJ-window sprite covers this pixel on the current scanline
+    bool obj_window[SCREEN_WIDTH];
+
+    // Per-pixel flag set by windowing: false = color effects disabled for this pixel
+    bool win_blend_enable[SCREEN_WIDTH];
+
     // Memory pointers (point into bus memory)
     uint8_t* palette_ram;
     uint8_t* vram;
@@ -74,8 +80,10 @@ void ppu_render_mode5(PPU* ppu);
 // Sprite renderer (sprites.c)
 void ppu_render_sprites_at_priority(PPU* ppu, int priority);
 void ppu_render_sprites(PPU* ppu);
+void ppu_build_obj_window(PPU* ppu);
 
 // Effects (effects.c)
+void ppu_apply_windowing_scanline(PPU* ppu);
 void ppu_apply_blend_scanline(PPU* ppu);
 
 #endif // PPU_H

--- a/src/ppu/sprites.c
+++ b/src/ppu/sprites.c
@@ -59,6 +59,14 @@ void ppu_render_sprites_at_priority(PPU* ppu, int priority) {
         if (obj_mode == 2) continue;  // Disabled sprite
         if (obj_mode == 1 || obj_mode == 3) continue;  // Affine: skip for now
 
+        // GFX Mode: attr0 bits 11-10
+        // 0 = Normal, 1 = Semi-transparent, 2 = OBJ window
+        uint8_t gfx_mode = BITS(attr0, 11, 10);
+
+        // OBJ window sprites are not rendered visually and ignore priority.
+        // They only mark pixels in the obj_window buffer.
+        if (gfx_mode == 2) continue;  // Handled in a separate pass
+
         // Priority: attr2 bits 11-10
         uint8_t sprite_prio = BITS(attr2, 11, 10);
         if (sprite_prio != (uint8_t)priority) continue;
@@ -198,5 +206,117 @@ void ppu_render_sprites_at_priority(PPU* ppu, int priority) {
 void ppu_render_sprites(PPU* ppu) {
     for (int p = 3; p >= 0; p--) {
         ppu_render_sprites_at_priority(ppu, p);
+    }
+}
+
+// Build the OBJ window mask for the current scanline.
+// Sprites with GFX mode 2 (attr0 bits 11-10) mark non-transparent pixels in
+// ppu->obj_window[]. These sprites are NOT drawn visually; they only define
+// the OBJ window region. Priority and blending are irrelevant for them.
+void ppu_build_obj_window(PPU* ppu) {
+    memset(ppu->obj_window, 0, sizeof(ppu->obj_window));
+
+    // OBJ window requires DISPCNT bit 15 (OBJ Window Display Flag)
+    if (!BIT(ppu->dispcnt, 15)) return;
+
+    // Also need OBJ layer enabled
+    if (!BIT(ppu->dispcnt, 12)) return;
+
+    bool mapping_1d = BIT(ppu->dispcnt, 6);
+    uint16_t scanline = ppu->vcount;
+
+    for (int32_t i = OAM_ENTRY_COUNT - 1; i >= 0; i--) {
+        uint32_t oam_base = (uint32_t)i * OAM_ENTRY_SIZE;
+
+        uint16_t attr0 = (uint16_t)ppu->oam[oam_base]
+                       | ((uint16_t)ppu->oam[oam_base + 1] << 8);
+        uint16_t attr1 = (uint16_t)ppu->oam[oam_base + 2]
+                       | ((uint16_t)ppu->oam[oam_base + 3] << 8);
+        uint16_t attr2 = (uint16_t)ppu->oam[oam_base + 4]
+                       | ((uint16_t)ppu->oam[oam_base + 5] << 8);
+
+        uint8_t obj_mode = BITS(attr0, 9, 8);
+        if (obj_mode == 2) continue;  // Disabled
+        if (obj_mode == 1 || obj_mode == 3) continue;  // Affine: skip for now
+
+        // Only process GFX mode 2 (OBJ window) sprites
+        uint8_t gfx_mode = BITS(attr0, 11, 10);
+        if (gfx_mode != 2) continue;
+
+        uint8_t shape = BITS(attr0, 15, 14);
+        uint8_t size  = BITS(attr1, 15, 14);
+        if (shape > 2) continue;
+
+        uint8_t width  = sprite_width[shape][size];
+        uint8_t height = sprite_height[shape][size];
+
+        int32_t sprite_y = BITS(attr0, 7, 0);
+        if (sprite_y >= 160) sprite_y -= 256;
+
+        int32_t local_y = (int32_t)scanline - sprite_y;
+        if (local_y < 0 || local_y >= height) continue;
+
+        int32_t sprite_x = BITS(attr1, 8, 0);
+        if (BIT(attr1, 8)) {
+            sprite_x |= (int32_t)0xFFFFFE00;
+        }
+
+        bool color_8bpp = BIT(attr0, 13);
+        uint16_t base_tile = BITS(attr2, 9, 0);
+        if (color_8bpp) base_tile &= ~(uint16_t)1;
+
+        bool h_flip = BIT(attr1, 12);
+        bool v_flip = BIT(attr1, 13);
+        int32_t tex_y = v_flip ? (height - 1 - local_y) : local_y;
+
+        for (int32_t px = 0; px < width; px++) {
+            int32_t screen_x = sprite_x + px;
+            if (screen_x < 0 || screen_x >= SCREEN_WIDTH) continue;
+
+            int32_t tex_x = h_flip ? (width - 1 - px) : px;
+
+            uint32_t tile_row = (uint32_t)tex_y / 8;
+            uint32_t tile_col = (uint32_t)tex_x / 8;
+            uint32_t pixel_row = (uint32_t)tex_y % 8;
+            uint32_t pixel_col = (uint32_t)tex_x % 8;
+
+            uint16_t tile_num;
+            if (color_8bpp) {
+                if (mapping_1d) {
+                    tile_num = base_tile
+                             + (uint16_t)(tile_row * ((uint32_t)width / 8) + tile_col) * 2;
+                } else {
+                    tile_num = base_tile
+                             + (uint16_t)(tile_row * 32 + tile_col * 2);
+                }
+            } else {
+                if (mapping_1d) {
+                    tile_num = base_tile
+                             + (uint16_t)(tile_row * ((uint32_t)width / 8) + tile_col);
+                } else {
+                    tile_num = base_tile
+                             + (uint16_t)(tile_row * 32 + tile_col);
+                }
+            }
+
+            uint32_t tile_addr = OBJ_TILE_BASE + (uint32_t)tile_num * 32;
+            uint8_t color_idx;
+
+            if (color_8bpp) {
+                uint32_t offset = tile_addr + pixel_row * 8 + pixel_col;
+                if (offset >= VRAM_SIZE) offset -= VRAM_MIRROR_OFFSET;
+                color_idx = ppu->vram[offset];
+            } else {
+                uint32_t offset = tile_addr + pixel_row * 4 + pixel_col / 2;
+                if (offset >= VRAM_SIZE) offset -= VRAM_MIRROR_OFFSET;
+                uint8_t byte = ppu->vram[offset];
+                color_idx = (pixel_col & 1) ? (byte >> 4) : (byte & 0x0F);
+            }
+
+            // Only non-transparent pixels contribute to the OBJ window
+            if (color_idx != 0) {
+                ppu->obj_window[screen_x] = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Implement PPU windowing (WIN0, WIN1, OBJ window)** — Adds full window support to the scanline rendering pipeline. WIN0/WIN1 rectangular windows with coordinate wrapping, OBJ window via GFX mode 2 sprites, per-pixel layer enable masks from WININ/WINOUT registers, and color effects enable/disable per window region. Window priority follows hardware spec: WIN0 > WIN1 > OBJWIN > outside.
- **Update CLAUDE.md** — Reflects the actual implementation state: Phases 1-4 complete, documents the X-Ray debug mode, HLE BIOS, known gaps, and corrects the project structure.
- **Fix CMakeLists.txt** — Link libm for bios_hle.c atan2 usage.

## Test plan

- [ ] Build with `cmake .. -DCMAKE_BUILD_TYPE=Debug && make` — zero warnings
- [ ] Verify windowing with tonc demo ROMs (win_demo)
- [ ] Test Pokemon Emerald text boxes and battle transition overlays render correctly
- [ ] Confirm no regression in non-windowed rendering (windowing early-exits when DISPCNT bits 13-15 are all clear)

https://claude.ai/code/session_01FKdKCTSDn9ZWJJrem1H8n4