### PR TITLE
Add cheat code system (GameShark/Action Replay + CodeBreaker)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,9 @@ mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug && make
 # Run without BIOS (HLE BIOS kicks in automatically)
 ./gba_emulator <rom.gba> --scale 3
 
+# Run with cheat codes
+./gba_emulator <rom.gba> --cheats cheats/emerald.cht
+
 # Build without Hardware X-Ray Mode
 mkdir -p build && cd build && cmake .. -DENABLE_XRAY=OFF && make
 
@@ -61,6 +64,9 @@ src/
     rtc.h/c            Real-time clock via GPIO pins (partially implemented)
     sram.c             Battery-backed SRAM
     eeprom.c           EEPROM (stub — not needed for Emerald)
+  cheat/
+    cheat.h/c          Cheat engine — GameShark/Action Replay + CodeBreaker
+    cheat_file.h/c     Cheat file (.cht) parser and writer
   input/input.h/c      Keypad registers (active-low), KEYCNT for key IRQs
   frontend/
     frontend.h/c       SDL2 window, rendering, input polling, audio output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ src/
     background.c       Tiled BG rendering (modes 0-2)
     bitmap.c           Bitmap modes 3-5
     sprites.c          OAM sprite rendering
-    effects.c          Blending, windowing (functional), mosaic (stub)
+    effects.c          Blending, windowing, mosaic
     affine.c           Rotation/scaling math
   apu/                 Audio Processing Unit
     apu.h/c            Mixer, FIFO management, sample buffer
@@ -158,13 +158,12 @@ Current target: **Pokemon Emerald from boot to credits.**
 |-------|-------|--------|
 | 1 | CPU (ARM + Thumb instructions) + Memory Bus | **Complete** — full ARM/Thumb decoders, HLE BIOS, DMA, pipeline |
 | 2 | PPU basics + SDL2 frontend (see pixels) | **Complete** — bitmap modes, tiled BG, scanline renderer |
-| 3 | Full PPU + sprites (title screen renders) | **Complete** — sprites, affine, blending, windowing work. Mosaic stubbed |
+| 3 | Full PPU + sprites (title screen renders) | **Complete** — sprites, affine, blending, windowing, mosaic |
 | 4 | Audio (timers + DMA + FIFO chain) | **Complete** — FIFO playback, legacy channels, DAC filter, SDL audio |
 | 5 | Flash 128K save + RTC | **Partially complete** — Flash 64K/128K + SRAM work. EEPROM & RTC stubbed |
 | 6 | Polish + accuracy (full playthrough) | In progress |
 
 ### Known gaps (not yet implemented)
-- **Mosaic effect** — declared in effects.c but not functional
 - **EEPROM save protocol** — bit-serial protocol not implemented (not needed for Emerald)
 - **RTC GPIO serial** — partially implemented, not fully functional
 - **WAITCNT register** — stubbed, no cartridge wait-state timing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ set(SOURCES
     src/cartridge/eeprom.c
     src/cartridge/rtc.c
     src/input/input.c
+    src/cheat/cheat.c
+    src/cheat/cheat_file.c
     src/frontend/frontend.c
 )
 

--- a/src/cheat/cheat.c
+++ b/src/cheat/cheat.c
@@ -1,0 +1,222 @@
+#include "cheat.h"
+#include "memory/bus.h"
+#include <string.h>
+
+void cheat_init(CheatEngine* engine) {
+    memset(engine, 0, sizeof(CheatEngine));
+}
+
+int32_t cheat_add(CheatEngine* engine, const char* name,
+                  CheatFormat format, const CheatCode* codes,
+                  uint32_t code_count) {
+    if (engine->cheat_count >= CHEAT_MAX_CHEATS) return -1;
+    if (code_count == 0 || code_count > CHEAT_MAX_LINES) return -1;
+
+    CheatEntry* entry = &engine->cheats[engine->cheat_count];
+    strncpy(entry->name, name, CHEAT_NAME_LEN - 1);
+    entry->name[CHEAT_NAME_LEN - 1] = '\0';
+    entry->format = format;
+    memcpy(entry->codes, codes, code_count * sizeof(CheatCode));
+    entry->code_count = code_count;
+    entry->enabled = true;
+
+    return (int32_t)engine->cheat_count++;
+}
+
+void cheat_remove(CheatEngine* engine, uint32_t index) {
+    if (index >= engine->cheat_count) return;
+
+    // Shift remaining entries down
+    for (uint32_t i = index; i < engine->cheat_count - 1; i++) {
+        engine->cheats[i] = engine->cheats[i + 1];
+    }
+    engine->cheat_count--;
+}
+
+void cheat_toggle(CheatEngine* engine, uint32_t index) {
+    if (index >= engine->cheat_count) return;
+    engine->cheats[index].enabled = !engine->cheats[index].enabled;
+}
+
+void cheat_clear_all(CheatEngine* engine) {
+    engine->cheat_count = 0;
+}
+
+// ---------------------------------------------------------------------------
+// GameShark v1/v2 / Action Replay decoder
+// ---------------------------------------------------------------------------
+// Code format: TTAAAAAA VVVVVVVV
+//   T  = type nibble (bits 31-28 of address word)
+//   A  = target address (bits 27-0)
+//   V  = value
+//
+// Supported types:
+//   0 = 8-bit constant write
+//   1 = 16-bit constant write
+//   2 = 32-bit constant write
+//   3 = 8-bit if-equal (conditional: execute next code only if match)
+//   D = 16-bit if-equal (conditional)
+//   6 = 16-bit slide code (repeated writes)
+
+static void apply_gameshark(CheatEntry* entry, Bus* bus) {
+    bool skip_next = false;
+
+    for (uint32_t i = 0; i < entry->code_count; i++) {
+        CheatCode* code = &entry->codes[i];
+        uint8_t type = (uint8_t)(code->address >> 28);
+        uint32_t addr = code->address & 0x0FFFFFFF;
+        uint32_t val = code->value;
+
+        if (skip_next) {
+            skip_next = false;
+            continue;
+        }
+
+        switch (type) {
+        case 0x0:
+            // 8-bit constant write
+            bus_write8(bus, addr, (uint8_t)(val & 0xFF));
+            break;
+
+        case 0x1:
+            // 16-bit constant write
+            bus_write16(bus, addr, (uint16_t)(val & 0xFFFF));
+            break;
+
+        case 0x2:
+            // 32-bit constant write
+            bus_write32(bus, addr, val);
+            break;
+
+        case 0x3:
+            // 8-bit if-equal: skip next code if memory != value
+            if (bus_read8(bus, addr) != (uint8_t)(val & 0xFF)) {
+                skip_next = true;
+            }
+            break;
+
+        case 0x6: {
+            // Slide code: repeated 16-bit writes
+            // Code format: 6AAAAAAA 0000VVVV
+            // Next code:   NNNN0000 DDDDEEEE
+            //   N = repeat count, D = address increment, E = value increment
+            if (i + 1 >= entry->code_count) break;
+
+            CheatCode* slide = &entry->codes[i + 1];
+            uint16_t write_val = (uint16_t)(val & 0xFFFF);
+            uint16_t count = (uint16_t)(slide->address >> 16);
+            uint16_t addr_inc = (uint16_t)(slide->value >> 16);
+            uint16_t val_inc = (uint16_t)(slide->value & 0xFFFF);
+
+            uint32_t cur_addr = addr;
+            uint16_t cur_val = write_val;
+            for (uint16_t n = 0; n < count; n++) {
+                bus_write16(bus, cur_addr, cur_val);
+                cur_addr += addr_inc;
+                cur_val += val_inc;
+            }
+            i++; // Consume the slide parameter line
+            break;
+        }
+
+        case 0xD:
+            // 16-bit if-equal: skip next code if memory != value
+            if (bus_read16(bus, addr) != (uint16_t)(val & 0xFFFF)) {
+                skip_next = true;
+            }
+            break;
+
+        default:
+            LOG_WARN("[CHEAT] Unknown GameShark type: 0x%X (code %08X %08X)",
+                     type, code->address, code->value);
+            break;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CodeBreaker decoder
+// ---------------------------------------------------------------------------
+// Code format: TTAAAAAA VVVVVVVV
+//   T  = type nibble (bits 31-28 of address word)
+//   A  = target address (bits 27-0)
+//   V  = value
+//
+// Supported types:
+//   0 = 32-bit constant write
+//   1 = 16-bit constant write
+//   2 = 8-bit constant write
+//   3 = 32-bit if-equal (conditional)
+//   7 = 16-bit if-greater-than (conditional: skip next if memory <= value)
+
+static void apply_codebreaker(CheatEntry* entry, Bus* bus) {
+    bool skip_next = false;
+
+    for (uint32_t i = 0; i < entry->code_count; i++) {
+        CheatCode* code = &entry->codes[i];
+        uint8_t type = (uint8_t)(code->address >> 28);
+        uint32_t addr = code->address & 0x0FFFFFFF;
+        uint32_t val = code->value;
+
+        if (skip_next) {
+            skip_next = false;
+            continue;
+        }
+
+        switch (type) {
+        case 0x0:
+            // 32-bit constant write
+            bus_write32(bus, addr, val);
+            break;
+
+        case 0x1:
+            // 16-bit constant write
+            bus_write16(bus, addr, (uint16_t)(val & 0xFFFF));
+            break;
+
+        case 0x2:
+            // 8-bit constant write
+            bus_write8(bus, addr, (uint8_t)(val & 0xFF));
+            break;
+
+        case 0x3:
+            // 32-bit if-equal: skip next code if memory != value
+            if (bus_read32(bus, addr) != val) {
+                skip_next = true;
+            }
+            break;
+
+        case 0x7:
+            // 16-bit if-greater-than: skip next if memory <= value
+            if (bus_read16(bus, addr) <= (uint16_t)(val & 0xFFFF)) {
+                skip_next = true;
+            }
+            break;
+
+        default:
+            LOG_WARN("[CHEAT] Unknown CodeBreaker type: 0x%X (code %08X %08X)",
+                     type, code->address, code->value);
+            break;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public apply function
+// ---------------------------------------------------------------------------
+
+void cheat_apply(CheatEngine* engine, Bus* bus) {
+    for (uint32_t i = 0; i < engine->cheat_count; i++) {
+        CheatEntry* entry = &engine->cheats[i];
+        if (!entry->enabled) continue;
+
+        switch (entry->format) {
+        case CHEAT_FORMAT_GAMESHARK:
+            apply_gameshark(entry, bus);
+            break;
+        case CHEAT_FORMAT_CODEBREAKER:
+            apply_codebreaker(entry, bus);
+            break;
+        }
+    }
+}

--- a/src/cheat/cheat.h
+++ b/src/cheat/cheat.h
@@ -1,0 +1,55 @@
+#ifndef CHEAT_H
+#define CHEAT_H
+
+#include "common.h"
+
+// Forward declarations
+typedef struct Bus Bus;
+
+// Limits (static allocation)
+#define CHEAT_MAX_CHEATS      64    // Max named cheat groups
+#define CHEAT_MAX_LINES       16    // Max code lines per cheat group
+#define CHEAT_NAME_LEN        64    // Max name length per cheat
+
+// Cheat code format
+typedef enum {
+    CHEAT_FORMAT_GAMESHARK,     // GameShark v1/v2 / Action Replay
+    CHEAT_FORMAT_CODEBREAKER    // CodeBreaker / GameShark Advance
+} CheatFormat;
+
+// A single raw code line (one address/value pair)
+typedef struct {
+    uint32_t address;   // First 32 bits (encodes type + address)
+    uint32_t value;     // Second 32 bits (value / parameter)
+} CheatCode;
+
+// A named cheat (e.g., "Infinite HP") consisting of 1+ code lines
+typedef struct {
+    char name[CHEAT_NAME_LEN];
+    CheatFormat format;
+    CheatCode codes[CHEAT_MAX_LINES];
+    uint32_t code_count;
+    bool enabled;
+} CheatEntry;
+
+// Top-level cheat engine state
+typedef struct {
+    CheatEntry cheats[CHEAT_MAX_CHEATS];
+    uint32_t cheat_count;
+} CheatEngine;
+
+// Lifecycle
+void cheat_init(CheatEngine* engine);
+
+// Management — cheat_add returns index of new cheat, or -1 if full
+int32_t cheat_add(CheatEngine* engine, const char* name,
+                  CheatFormat format, const CheatCode* codes,
+                  uint32_t code_count);
+void cheat_remove(CheatEngine* engine, uint32_t index);
+void cheat_toggle(CheatEngine* engine, uint32_t index);
+void cheat_clear_all(CheatEngine* engine);
+
+// Apply all enabled cheats (call once per frame at VBlank)
+void cheat_apply(CheatEngine* engine, Bus* bus);
+
+#endif // CHEAT_H

--- a/src/cheat/cheat_file.c
+++ b/src/cheat/cheat_file.c
@@ -1,0 +1,155 @@
+#include "cheat_file.h"
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <inttypes.h>
+
+// Maximum line length in a .cht file
+#define LINE_BUF_SIZE 512
+
+// Trim leading/trailing whitespace in-place, return pointer to trimmed start
+static char* trim(char* str) {
+    while (*str && isspace((unsigned char)*str)) str++;
+    if (*str == '\0') return str;
+    char* end = str + strlen(str) - 1;
+    while (end > str && isspace((unsigned char)*end)) *end-- = '\0';
+    return str;
+}
+
+// Flush the current cheat entry being accumulated into the engine.
+// Returns true if a cheat was added, false if nothing to flush.
+static bool flush_entry(CheatEngine* engine, const char* name,
+                        CheatFormat format, const CheatCode* codes,
+                        uint32_t code_count, bool enabled) {
+    if (code_count == 0) return false;
+    if (name[0] == '\0') {
+        LOG_WARN("[CHEAT] Cheat block with %u codes has no name, skipping",
+                 code_count);
+        return false;
+    }
+
+    int32_t idx = cheat_add(engine, name, format, codes, code_count);
+    if (idx < 0) return false;
+
+    engine->cheats[idx].enabled = enabled;
+    return true;
+}
+
+int32_t cheat_file_load(CheatEngine* engine, const char* path) {
+    FILE* fp = fopen(path, "r");
+    if (!fp) return -1;
+
+    char line_buf[LINE_BUF_SIZE];
+    int32_t loaded = 0;
+
+    // Accumulator for current cheat being parsed
+    char cur_name[CHEAT_NAME_LEN] = {0};
+    CheatFormat cur_format = CHEAT_FORMAT_GAMESHARK;
+    CheatCode cur_codes[CHEAT_MAX_LINES];
+    uint32_t cur_code_count = 0;
+    bool cur_enabled = true;
+    bool in_block = false;
+
+    while (fgets(line_buf, LINE_BUF_SIZE, fp)) {
+        char* line = trim(line_buf);
+
+        // Skip empty lines and comments
+        if (*line == '\0' || *line == '#') continue;
+
+        // Format header starts a new block
+        if (*line == '[') {
+            // Flush previous block
+            if (in_block) {
+                if (flush_entry(engine, cur_name, cur_format,
+                                cur_codes, cur_code_count, cur_enabled)) {
+                    loaded++;
+                }
+            }
+
+            // Reset accumulator
+            cur_name[0] = '\0';
+            cur_code_count = 0;
+            cur_enabled = true;
+            in_block = true;
+
+            if (strncmp(line, "[GameShark]", 11) == 0 ||
+                strncmp(line, "[ActionReplay]", 14) == 0) {
+                cur_format = CHEAT_FORMAT_GAMESHARK;
+            } else if (strncmp(line, "[CodeBreaker]", 13) == 0) {
+                cur_format = CHEAT_FORMAT_CODEBREAKER;
+            } else {
+                LOG_WARN("[CHEAT] Unknown format header: %s", line);
+                in_block = false;
+            }
+            continue;
+        }
+
+        if (!in_block) continue;
+
+        // name=<text>
+        if (strncmp(line, "name=", 5) == 0) {
+            strncpy(cur_name, line + 5, CHEAT_NAME_LEN - 1);
+            cur_name[CHEAT_NAME_LEN - 1] = '\0';
+            continue;
+        }
+
+        // enabled=true|false
+        if (strncmp(line, "enabled=", 8) == 0) {
+            cur_enabled = (strcmp(line + 8, "true") == 0);
+            continue;
+        }
+
+        // Try to parse as a hex code line: XXXXXXXX YYYYYYYY or XXXXXXXX YYYY
+        if (cur_code_count >= CHEAT_MAX_LINES) continue;
+
+        uint32_t addr = 0, val = 0;
+        if (sscanf(line, "%8" SCNx32 " %8" SCNx32, &addr, &val) == 2) {
+            cur_codes[cur_code_count].address = addr;
+            cur_codes[cur_code_count].value = val;
+            cur_code_count++;
+        }
+    }
+
+    // Flush final block
+    if (in_block) {
+        if (flush_entry(engine, cur_name, cur_format,
+                        cur_codes, cur_code_count, cur_enabled)) {
+            loaded++;
+        }
+    }
+
+    fclose(fp);
+    return loaded;
+}
+
+bool cheat_file_save(const CheatEngine* engine, const char* path) {
+    FILE* fp = fopen(path, "w");
+    if (!fp) return false;
+
+    fprintf(fp, "# GBA Cheat File\n\n");
+
+    for (uint32_t i = 0; i < engine->cheat_count; i++) {
+        const CheatEntry* entry = &engine->cheats[i];
+
+        switch (entry->format) {
+        case CHEAT_FORMAT_GAMESHARK:
+            fprintf(fp, "[GameShark]\n");
+            break;
+        case CHEAT_FORMAT_CODEBREAKER:
+            fprintf(fp, "[CodeBreaker]\n");
+            break;
+        }
+
+        fprintf(fp, "name=%s\n", entry->name);
+        fprintf(fp, "enabled=%s\n", entry->enabled ? "true" : "false");
+
+        for (uint32_t j = 0; j < entry->code_count; j++) {
+            fprintf(fp, "%08X %08X\n", entry->codes[j].address,
+                    entry->codes[j].value);
+        }
+        fprintf(fp, "\n");
+    }
+
+    fclose(fp);
+    return true;
+}

--- a/src/cheat/cheat_file.h
+++ b/src/cheat/cheat_file.h
@@ -1,0 +1,12 @@
+#ifndef CHEAT_FILE_H
+#define CHEAT_FILE_H
+
+#include "cheat.h"
+
+// Load cheats from a .cht file. Returns number of cheats loaded, or -1 on error.
+int32_t cheat_file_load(CheatEngine* engine, const char* path);
+
+// Save current cheats to a .cht file. Returns false on failure.
+bool cheat_file_save(const CheatEngine* engine, const char* path);
+
+#endif // CHEAT_FILE_H

--- a/src/gba.c
+++ b/src/gba.c
@@ -24,6 +24,7 @@ void gba_init(GBA* gba) {
     dma_init(&gba->dma);
     interrupt_init(&gba->interrupts);
     input_init(&gba->input);
+    cheat_init(&gba->cheats);
 
     // PPU gets pointers to VRAM/palette/OAM in bus — AFTER ppu_init()
     // so the memset inside ppu_init doesn't wipe them
@@ -95,6 +96,9 @@ void gba_run_frame(GBA* gba) {
             ppu_set_vblank(&gba->ppu, true);
             interrupt_request_if_enabled(&gba->interrupts, &gba->ppu, IRQ_VBLANK);
             dma_on_vblank(&gba->dma);
+
+            // Apply cheat codes at VBlank (matches real cheat device timing)
+            cheat_apply(&gba->cheats, &gba->bus);
 
             // Reload affine reference points from latches at VBlank start.
             // Per GBATEK: the internal reference point registers are reloaded

--- a/src/gba.h
+++ b/src/gba.h
@@ -11,6 +11,7 @@
 #include "interrupt/interrupt.h"
 #include "cartridge/cartridge.h"
 #include "input/input.h"
+#include "cheat/cheat.h"
 
 #ifdef ENABLE_XRAY
 typedef struct XRayState XRayState;
@@ -26,6 +27,7 @@ struct GBA {
     InterruptController interrupts;
     Cartridge cart;
     InputState input;
+    CheatEngine cheats;
 
     uint64_t total_cycles;
     bool frame_complete;

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include "gba.h"
 #include "cpu/arm7tdmi.h"
+#include "cheat/cheat_file.h"
 #include "frontend/frontend.h"
 #include <stdio.h>
 
@@ -13,6 +14,7 @@ static void print_usage(const char* prog) {
     printf("Options:\n");
     printf("  --bios <file>   Load GBA BIOS ROM\n");
     printf("  --scale <n>     Window scale factor (default: 3)\n");
+    printf("  --cheats <file> Load cheat codes from file (.cht format)\n");
 }
 
 int main(int argc, char* argv[]) {
@@ -23,6 +25,7 @@ int main(int argc, char* argv[]) {
 
     const char* rom_path = argv[1];
     const char* bios_path = NULL;
+    const char* cheat_path = NULL;
     int scale = 3;
 
     // Parse arguments
@@ -31,6 +34,8 @@ int main(int argc, char* argv[]) {
             bios_path = argv[++i];
         } else if (strcmp(argv[i], "--scale") == 0 && i + 1 < argc) {
             scale = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--cheats") == 0 && i + 1 < argc) {
+            cheat_path = argv[++i];
         }
     }
 
@@ -52,6 +57,16 @@ int main(int argc, char* argv[]) {
     if (!gba_load_rom(&gba, rom_path)) {
         LOG_ERROR("Failed to load ROM: %s", rom_path);
         return 1;
+    }
+
+    // Load cheat codes if provided
+    if (cheat_path) {
+        int32_t loaded = cheat_file_load(&gba.cheats, cheat_path);
+        if (loaded < 0) {
+            LOG_WARN("Failed to load cheat file: %s", cheat_path);
+        } else {
+            LOG_INFO("Loaded %d cheats from %s", loaded, cheat_path);
+        }
     }
 
     // Initialize frontend (SDL2)

--- a/src/ppu/background.c
+++ b/src/ppu/background.c
@@ -33,8 +33,18 @@ void ppu_render_bg_regular(PPU* ppu, int bg_index) {
     uint32_t hofs = ppu->bg_hofs[bg_index] & 0x1FF;
     uint32_t vofs = ppu->bg_vofs[bg_index] & 0x1FF;
 
+    // Apply vertical mosaic: snap Y to the top of the current mosaic block.
+    // BGxCNT bit 6 enables mosaic for this BG.
+    uint16_t effective_vcount = ppu->vcount;
+    if (BIT(bgcnt, 6)) {
+        uint16_t bg_v_size = BITS(ppu->mosaic, 7, 4) + 1;
+        if (bg_v_size > 1) {
+            effective_vcount = ppu->vcount - (ppu->vcount % bg_v_size);
+        }
+    }
+
     // Y coordinate within the full map (wrapping)
-    uint32_t map_y = (ppu->vcount + vofs) % map_height;
+    uint32_t map_y = (effective_vcount + vofs) % map_height;
 
     // Which tile row (0-31 or 0-63) and pixel row within that tile (0-7)
     uint32_t tile_row = map_y / 8;
@@ -43,9 +53,21 @@ void ppu_render_bg_regular(PPU* ppu, int bg_index) {
     // Number of screen blocks per row: 2 if map is 512 wide, else 1
     uint32_t sbb_width = (map_width > 256) ? 2 : 1;
 
+    // Horizontal mosaic size for this BG (only used if mosaic enabled)
+    uint16_t bg_h_size = 1;
+    if (BIT(bgcnt, 6)) {
+        bg_h_size = BITS(ppu->mosaic, 3, 0) + 1;
+    }
+
     for (uint32_t screen_x = 0; screen_x < SCREEN_WIDTH; screen_x++) {
+        // Apply horizontal mosaic: snap X to the leftmost pixel in the block
+        uint32_t fetch_x = screen_x;
+        if (bg_h_size > 1) {
+            fetch_x = screen_x - (screen_x % bg_h_size);
+        }
+
         // X coordinate within the full map (wrapping)
-        uint32_t map_x = (screen_x + hofs) % map_width;
+        uint32_t map_x = (fetch_x + hofs) % map_width;
 
         // Which tile column and pixel column within that tile
         uint32_t tile_col = map_x / 8;
@@ -157,14 +179,43 @@ void ppu_render_bg_affine(PPU* ppu, int bg_index) {
     int32_t px = ppu->bg_ref_x[affine_idx];
     int32_t py = ppu->bg_ref_y[affine_idx];
 
+    // Apply vertical mosaic: rewind ref point to the top of the mosaic block.
+    // Each scanline advances ref by PB/PD, so we subtract the delta for
+    // (vcount - mosaic_start) scanlines.
+    if (BIT(bgcnt, 6)) {
+        uint16_t bg_v_size = BITS(ppu->mosaic, 7, 4) + 1;
+        if (bg_v_size > 1) {
+            uint16_t lines_back = ppu->vcount % bg_v_size;
+            px -= (int32_t)ppu->bg_pb[affine_idx] * (int32_t)lines_back;
+            py -= (int32_t)ppu->bg_pd[affine_idx] * (int32_t)lines_back;
+        }
+    }
+
     // PA and PC control horizontal stepping within a scanline.
     int16_t pa = ppu->bg_pa[affine_idx];
     int16_t pc = ppu->bg_pc[affine_idx];
 
+    // Horizontal mosaic size for affine BG
+    uint16_t bg_h_size = 1;
+    if (BIT(bgcnt, 6)) {
+        bg_h_size = BITS(ppu->mosaic, 3, 0) + 1;
+    }
+
     for (uint32_t screen_x = 0; screen_x < SCREEN_WIDTH; screen_x++) {
+        // Apply horizontal mosaic: use texture coords from the block-start column.
+        // The reference point at block_start = px - (screen_x % bg_h_size) * PA,
+        // py - (screen_x % bg_h_size) * PC.
+        int32_t sample_px = px;
+        int32_t sample_py = py;
+        if (bg_h_size > 1) {
+            uint32_t offset_in_block = screen_x % bg_h_size;
+            sample_px = px - (int32_t)pa * (int32_t)offset_in_block;
+            sample_py = py - (int32_t)pc * (int32_t)offset_in_block;
+        }
+
         // Convert from 8.8 fixed-point to integer pixel coordinates
-        int32_t tex_x = px >> 8;
-        int32_t tex_y = py >> 8;
+        int32_t tex_x = sample_px >> 8;
+        int32_t tex_y = sample_py >> 8;
 
         // Bounds check / wraparound
         if (wraparound) {

--- a/src/ppu/effects.c
+++ b/src/ppu/effects.c
@@ -223,15 +223,34 @@ void ppu_apply_windowing_scanline(PPU* ppu) {
 }
 
 // ---------------------------------------------------------------------------
-// Mosaic (stub -- not yet implemented)
+// Mosaic
 // ---------------------------------------------------------------------------
 
-// Apply mosaic effect to background or sprite scanline
-void ppu_apply_mosaic(PPU* ppu, uint16_t* scanline, int width, bool is_obj) {
-    // TODO: Group pixels into mosaic_h x mosaic_v blocks
-    // All pixels in a block take the color of the top-left pixel
-    (void)ppu;
-    (void)scanline;
-    (void)width;
-    (void)is_obj;
+// Apply mosaic post-processing to the composited scanline.
+//
+// BG horizontal mosaic is handled during per-BG rendering (background.c snaps
+// the source X coordinate). BG vertical mosaic is also in background.c.
+// OBJ vertical mosaic is in sprites.c (snaps local_y per-sprite).
+//
+// This function handles OBJ horizontal mosaic as a post-process, using the
+// per-pixel obj_mosaic[] flag set by sprites.c to respect per-sprite enable.
+//
+// MOSAIC register (0x400004C):
+//   Bits 8-11:  OBJ mosaic H-size (minus 1)
+void ppu_apply_mosaic_scanline(PPU* ppu) {
+    uint16_t obj_h_size = BITS(ppu->mosaic, 11, 8) + 1;
+    if (obj_h_size <= 1) return;
+
+    for (uint32_t x = 0; x < SCREEN_WIDTH; x++) {
+        // Only apply to OBJ pixels from mosaic-enabled sprites
+        if (ppu->top_layer[x] != 4) continue;
+        if (!ppu->obj_mosaic[x]) continue;
+
+        uint32_t block_start = x - (x % obj_h_size);
+        if (block_start != x
+            && ppu->top_layer[block_start] == 4
+            && ppu->obj_mosaic[block_start]) {
+            ppu->scanline_buffer[x] = ppu->scanline_buffer[block_start];
+        }
+    }
 }

--- a/src/ppu/ppu.c
+++ b/src/ppu/ppu.c
@@ -35,6 +35,7 @@ void ppu_render_scanline(PPU* ppu) {
         ppu->second_pixel[x] = backdrop;
         ppu->second_layer[x] = 5;    // backdrop
         ppu->win_blend_enable[x] = true;
+        ppu->obj_mosaic[x] = false;
     }
 
     switch (mode) {
@@ -96,6 +97,10 @@ void ppu_render_scanline(PPU* ppu) {
         if (BIT(ppu->dispcnt, 12)) ppu_render_sprites(ppu);
         break;
     }
+
+    // Apply mosaic: horizontal post-process on composited pixels.
+    // Vertical mosaic is already applied during BG/sprite rendering.
+    ppu_apply_mosaic_scanline(ppu);
 
     // Build OBJ window mask (must happen after sprite rendering)
     ppu_build_obj_window(ppu);

--- a/src/ppu/ppu.h
+++ b/src/ppu/ppu.h
@@ -48,6 +48,9 @@ struct PPU {
     // OBJ window: true if an OBJ-window sprite covers this pixel on the current scanline
     bool obj_window[SCREEN_WIDTH];
 
+    // Per-pixel flag: true if the top OBJ pixel was from a mosaic-enabled sprite
+    bool obj_mosaic[SCREEN_WIDTH];
+
     // Per-pixel flag set by windowing: false = color effects disabled for this pixel
     bool win_blend_enable[SCREEN_WIDTH];
 
@@ -83,6 +86,7 @@ void ppu_render_sprites(PPU* ppu);
 void ppu_build_obj_window(PPU* ppu);
 
 // Effects (effects.c)
+void ppu_apply_mosaic_scanline(PPU* ppu);
 void ppu_apply_windowing_scanline(PPU* ppu);
 void ppu_apply_blend_scanline(PPU* ppu);
 

--- a/src/ppu/sprites.c
+++ b/src/ppu/sprites.c
@@ -90,6 +90,15 @@ void ppu_render_sprites_at_priority(PPU* ppu, int priority) {
         int32_t local_y = (int32_t)scanline - sprite_y;
         if (local_y < 0 || local_y >= height) continue;
 
+        // Apply vertical mosaic: snap sprite row to the top of the mosaic block.
+        // OAM attr0 bit 12 enables mosaic for this sprite.
+        if (BIT(attr0, 12)) {
+            uint16_t obj_v_size = BITS(ppu->mosaic, 15, 12) + 1;
+            if (obj_v_size > 1) {
+                local_y = local_y - (local_y % (int32_t)obj_v_size);
+            }
+        }
+
         // X coordinate: attr1 bits 8-0 (9-bit signed via sign-extending bit 8)
         int32_t sprite_x = BITS(attr1, 8, 0);
         if (BIT(attr1, 8)) {
@@ -196,6 +205,7 @@ void ppu_render_sprites_at_priority(PPU* ppu, int priority) {
             ppu->second_layer[screen_x] = ppu->top_layer[screen_x];
             ppu->scanline_buffer[screen_x] = color;
             ppu->top_layer[screen_x] = 4;  // OBJ layer
+            ppu->obj_mosaic[screen_x] = BIT(attr0, 12);
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Cheat code engine** supporting GameShark v1/v2 / Action Replay and CodeBreaker formats, with constant writes (8/16/32-bit), conditional codes, and slide codes
- **`.cht` file parser/writer** for loading/saving named cheat groups with enable/disable state
- **CLI integration** via `--cheats <file>` argument; cheats apply at VBlank through the bus (matching real cheat device timing)
- **Mosaic effect** fully implemented for BG and OBJ layers (vertical + horizontal), completing the PPU feature set
- **CLAUDE.md updates** fixing outdated statuses (windowing, mosaic) and documenting the new cheat system

### Cheat file format example
```
[GameShark]
name=Infinite Money
enabled=true
02000084 000F423F

[CodeBreaker]
name=Max HP
enabled=true
10004820 03E7
```

### Supported code types
| Format | Types |
|--------|-------|
| GameShark | 8/16/32-bit writes, 8-bit & 16-bit conditionals, slide codes |
| CodeBreaker | 8/16/32-bit writes, 32-bit if-equal, 16-bit if-greater-than |

## Test plan
- [ ] Build passes with zero warnings (`cmake .. -DCMAKE_BUILD_TYPE=Debug && make`)
- [ ] `--cheats` CLI argument accepted and cheat file parsed (check LOG_INFO output)
- [ ] GameShark constant write codes modify memory correctly (verify with X-Ray memory view)
- [ ] CodeBreaker constant write codes modify memory correctly
- [ ] Conditional codes only apply when condition is met
- [ ] Slide codes produce repeated writes with correct address/value increments
- [ ] Cheats with `enabled=false` in .cht file are loaded but not applied
- [ ] Malformed cheat files produce warnings without crashing
- [ ] Pokemon Emerald runs normally with no cheats loaded (no regression)
- [ ] Pokemon Emerald money cheat works with a real GameShark code

https://claude.ai/code/session_01XRcS4erKq19DJ8vLXpTdrs